### PR TITLE
Add metadata to Trie leaf nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ trie.n_closest("0001", 1) # ["0000"]
 trie.n_closest("0010", 3) # ["0010", "0011", "0000"]
 ```
 
+### Attaching metadata to Trie nodes
+
+It is possible to attach an `object` as metadata to a trie leaf node.
+
+```python
+class MyObj(object):
+    def __init__(self, key, name):
+        self.key = key
+        self.name = name
+
+obj = MyObj(int_to_bitstring(10, 4), "Node 10")
+trie.add(obj.key, obj)
+
+trie.find(obj.key).name # "Node 10"
+trie.n_closest(obj.key, 1) # [obj]
+```
+
 ### Helpers
 
 There are 4 helpers functions to facilitate the use of this implementation with keys being not only `bitstring`, but also `bytes` or `int`. These helper functions help translate `bytes` and `int` to `bitstring` and reciprocally.

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,61 @@
+import unittest
+
+from trie import Trie
+from helpers import bytes_to_bitstring, bitstring_to_bytes, int_to_bitstring, bitstring_to_int
+
+class TestStringMethods(unittest.TestCase):
+
+    def test_simple_trie(self):
+        t = Trie()
+        nodeIDs = [2,3,4,6,7,9,11,13]
+        for i in nodeIDs:
+            self.assertTrue(t.add(int_to_bitstring(i, 4)))
+
+        self.assertFalse(t.add(int_to_bitstring(2, 4)))
+
+        self.assertEqual(t.size, 8)
+
+        self.assertTrue(t.find("0010"))
+        self.assertFalse(t.find("0001"))
+        self.assertFalse(t.find("00100"))
+
+        self.assertEqual(t.n_closest("0010", 1), ["0010"])
+        self.assertEqual(t.n_closest("0010", 3), ["0010", "0011", "0110"])
+        self.assertEqual(t.n_closest("0010", 8), ["0010", "0011", "0110", "0111", "0100", "1011", "1001", "1101"])
+        self.assertEqual(t.n_closest("0010", 25), ["0010", "0011", "0110", "0111", "0100", "1011", "1001", "1101"])
+
+    def test_simple_metadata_trie(self):
+        class SimpleObj(object):
+            def __init__(self, key, name):
+                self.key = key
+                self.name = name
+
+        t = Trie()
+        nodeIDs = [2,3,4,6,7,9,11,13]
+
+        objs = []
+        for i in nodeIDs:
+            objs.append(SimpleObj(int_to_bitstring(i, 4),"Node "+str(i)))
+            self.assertTrue(t.add(int_to_bitstring(i, 4), metadata=objs[-1]))
+
+        self.assertFalse(t.add(int_to_bitstring(2, 4), metadata=objs[0]))
+
+        self.assertEqual(t.size, 8)
+
+        self.assertEquals(t.find("0010"), objs[0])
+        self.assertFalse(t.find("0001"))
+        self.assertFalse(t.find("00100"))
+
+        self.assertEqual(t.n_closest("0010", 1), [objs[0]])
+        self.assertEqual(t.n_closest("0010", 3), [objs[0], objs[1], objs[3]])
+        self.assertEqual(t.n_closest("0010", 8), [objs[0], objs[1], objs[3], objs[4], objs[2], objs[6], objs[5], objs[7]])
+        self.assertEqual(t.n_closest("0010", 25), [objs[0], objs[1], objs[3], objs[4], objs[2], objs[6], objs[5], objs[7]])
+
+        self.assertEqual(t.find("0011").name, "Node 3")
+        self.assertEqual(t.find("0011").key, int_to_bitstring(3, 4))
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trie.py
+++ b/trie.py
@@ -1,12 +1,14 @@
 
 class Trie(object):
 
-    def __init__(self, key: str=""):
+    def __init__(self, metadata=None, key: str=""):
+        self.metadata = metadata
         self.key = key # eg. "01110101"
         self.branch = [None, None]
         self.size = 0 # only counts the leaves
 
     def __repr__(self) -> str:
+        # "(branch[0].key / self.key \ branch[1].key)"
         rep = "("
         if self.branch[0] is not None:
             rep += self.branch[0].key + " / "
@@ -18,7 +20,7 @@ class Trie(object):
     # add the provided key to the trie
     # returns True on success and False on failure (usually
     # when the key is already in the trie)
-    def add(self, key: str) -> bool:
+    def add(self, key: str, metadata=None) -> bool:
         if self.branch[int(key[len(self.key)])] is not None:
             # branch already exists
             branch = self.branch[int(key[len(self.key)])]
@@ -35,7 +37,7 @@ class Trie(object):
                     #    /  \                  /   \
                     # 110  *111*     -->     1110  1111
 
-                    success = branch.add(key)
+                    success = branch.add(key=key, metadata=metadata)
             else:
                 # insert between two nodes in the trie
                 # 
@@ -52,7 +54,7 @@ class Trie(object):
                         # create mid Trie node
                         mid = Trie(key=branch.key[:i])
                         # define mid branches
-                        mid.branch[int(key[i])] = Trie(key=key)
+                        mid.branch[int(key[i])] = Trie(metadata=metadata, key=key)
                         mid.branch[1-int(key[i])] = branch
                         # set its size
                         mid.size = branch.size + 1
@@ -69,7 +71,7 @@ class Trie(object):
             #         -->       /     OR     /      -->       / \
             #                 001          001              001 110
 
-            self.branch[int(key[len(self.key)])] = Trie(key=key)
+            self.branch[int(key[len(self.key)])] = Trie(metadata=metadata, key=key)
             success=True
 
         if success:
@@ -79,7 +81,13 @@ class Trie(object):
     # returns True if key in trie and False otherwise
     def find(self, key: str) -> bool:
         if len(self.key) >= len(key):
-            return self.key == key
+            if self.key == key:
+                if self.metadata is None:
+                    return True
+                else:
+                    return self.metadata
+            else:
+                return False
         elif self.branch[int(key[len(self.key)])] is not None:
             return self.branch[int(key[len(self.key)])].find(key)
         else:
@@ -89,7 +97,10 @@ class Trie(object):
     def n_closest(self, key:str, n:int) -> list[str]:
         if self.branch[0] == self.branch[1] == None:
             # leaf of the trie
-            return [self.key]
+            if self.metadata is None:
+                return [self.key]
+            else:
+                return [self.metadata]
         
         nclosest = []
         if self.branch[int(key[len(self.key)])] is not None:


### PR DESCRIPTION
Trie nodes can now store generic metadata