### PR TITLE
Add formatting, n_closest predicate and typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,428 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,macos,linux,visualstudiocode,pycharm,intellij
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,macos,linux,visualstudiocode,pycharm,intellij
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# AWS User-specific
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# SonarLint plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+.vscode/*.code-snippets
+
+# Ignore code-workspaces
+*.code-workspace
+
+# End of https://www.toptal.com/developers/gitignore/api/python,macos,linux,visualstudiocode,pycharm,intellij

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/tests.py
+++ b/tests.py
@@ -1,13 +1,13 @@
 import unittest
 
 from trie import Trie
-from helpers import bytes_to_bitstring, bitstring_to_bytes, int_to_bitstring, bitstring_to_int
+from helpers import int_to_bitstring
+
 
 class TestStringMethods(unittest.TestCase):
-
     def test_simple_trie(self):
         t = Trie()
-        nodeIDs = [2,3,4,6,7,9,11,13]
+        nodeIDs = [2, 3, 4, 6, 7, 9, 11, 13]
         for i in nodeIDs:
             self.assertTrue(t.add(int_to_bitstring(i, 4)))
 
@@ -31,19 +31,19 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(t.find_trie("0").size, 5)
         self.assertEqual(t.find_trie("001").size, 2)
 
-
     def test_simple_metadata_trie(self):
         class SimpleObj(object):
-            def __init__(self, key, name):
+            def __init__(self, key, name, some_bool):
                 self.key = key
                 self.name = name
+                self.some_bool = some_bool
 
-        t = Trie()
-        nodeIDs = [2,3,4,6,7,9,11,13]
+        t = Trie(SimpleObj)
+        nodeIDs = [2, 3, 4, 6, 7, 9, 11, 13]
 
         objs = []
         for i in nodeIDs:
-            objs.append(SimpleObj(int_to_bitstring(i, 4),"Node "+str(i)))
+            objs.append(SimpleObj(int_to_bitstring(i, 4), "Node " + str(i), i % 3 == 0))
             self.assertTrue(t.add(int_to_bitstring(i, 4), metadata=objs[-1]))
 
         self.assertFalse(t.add(int_to_bitstring(2, 4), metadata=objs[0]))
@@ -56,8 +56,13 @@ class TestStringMethods(unittest.TestCase):
 
         self.assertEqual(t.n_closest("0010", 1), [objs[0]])
         self.assertEqual(t.n_closest("0010", 3), [objs[0], objs[1], objs[3]])
-        self.assertEqual(t.n_closest("0010", 8), [objs[0], objs[1], objs[3], objs[4], objs[2], objs[6], objs[5], objs[7]])
-        self.assertEqual(t.n_closest("0010", 25), [objs[0], objs[1], objs[3], objs[4], objs[2], objs[6], objs[5], objs[7]])
+        self.assertEqual(t.n_closest("0010", 3, predicate=lambda md: md.some_bool), [objs[1], objs[3], objs[5]])
+        self.assertEqual(
+            t.n_closest("0010", 8), [objs[0], objs[1], objs[3], objs[4], objs[2], objs[6], objs[5], objs[7]]
+        )
+        self.assertEqual(
+            t.n_closest("0010", 25), [objs[0], objs[1], objs[3], objs[4], objs[2], objs[6], objs[5], objs[7]]
+        )
 
         self.assertEqual(t.find("0011").name, "Node 3")
         self.assertEqual(t.find("0011").key, int_to_bitstring(3, 4))
@@ -70,6 +75,5 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(t.find_trie("001").size, 2)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/trie.py
+++ b/trie.py
@@ -1,11 +1,14 @@
+from typing import TypeVar, List, Callable, Optional, Generic
 
-class Trie(object):
+T = TypeVar("T")
 
-    def __init__(self, metadata=None, key: str=""):
+
+class Trie(Generic[T]):
+    def __init__(self, metadata=Optional[T], key: str = ""):
         self.metadata = metadata
-        self.key = key # eg. "01110101"
-        self.branch = [None, None]
-        self.size = 0 # only counts the leaves
+        self.key = key  # eg. "01110101"
+        self.branch: List[Optional[Trie], Optional[Trie]] = [None, None]
+        self.size = 0  # only counts the leaves
 
     def __repr__(self) -> str:
         # "(branch[0].key / self.key \ branch[1].key)"
@@ -15,19 +18,19 @@ class Trie(object):
         rep += self.key
         if self.branch[1] is not None:
             rep += " \ " + self.branch[1].key
-        return rep+")"
-                
+        return rep + ")"
+
     # add the provided key to the trie
     # returns True on success and False on failure (usually
     # when the key is already in the trie)
-    def add(self, key: str, metadata=None) -> bool:
+    def add(self, key: str, metadata: Optional[T] = None) -> bool:
         if self.branch[int(key[len(self.key)])] is not None:
             # branch already exists
             branch = self.branch[int(key[len(self.key)])]
 
             minLen = min(len(key), len(branch.key))
             if key[:minLen] == branch.key[:minLen]:
-                if len(key)==len(branch.key):
+                if len(key) == len(branch.key):
                     # key already in the trie, cannot insert it
                     return False
                 else:
@@ -40,7 +43,7 @@ class Trie(object):
                     success = branch.add(key=key, metadata=metadata)
             else:
                 # insert between two nodes in the trie
-                # 
+                #
                 #   11 +insert(111001)     11 self
                 #  / \                    / \
                 #     \       -->          1110 mid
@@ -48,7 +51,7 @@ class Trie(object):
                 #     111011     key 111001 111011 branch
 
                 for i in range(minLen):
-                    if branch.key[i]!=key[i]:
+                    if branch.key[i] != key[i]:
                         # first bit where branch.key and key diverge
 
                         # create mid Trie node
@@ -56,12 +59,12 @@ class Trie(object):
                         # define mid branches
                         mid.branch[int(key[i])] = Trie(metadata=metadata, key=key)
                         mid.branch[int(key[i])].size = 1
-                        mid.branch[1-int(key[i])] = branch
+                        mid.branch[1 - int(key[i])] = branch
                         # set its size
                         mid.size = branch.size + 1
                         # update self branch to mid
                         self.branch[int(key[len(self.key)])] = mid
-                        success=True
+                        success = True
 
                         break
         else:
@@ -74,13 +77,13 @@ class Trie(object):
 
             self.branch[int(key[len(self.key)])] = Trie(metadata=metadata, key=key)
             self.branch[int(key[len(self.key)])].size = 1
-            success=True
+            success = True
 
         if success:
-            self.size+=1
+            self.size += 1
         return success
 
-    def find_trie(self, key:str):
+    def find_trie(self, key: str):
         if len(self.key) >= len(key):
             if self.key == key:
                 return self
@@ -90,7 +93,7 @@ class Trie(object):
             return self.branch[int(key[len(self.key)])].find_trie(key)
         else:
             return None
-                
+
     # returns metadata associated with the key, if the key is in the trie and has metadata
     # True if key in trie but no metadata and False otherwise
     def find(self, key: str) -> bool:
@@ -104,20 +107,22 @@ class Trie(object):
 
     # returns a list of the metadata of the n closest keys in the Trie to the given key
     # returns a list of keys if no metadata
-    def n_closest(self, key:str, n:int) -> list[str]:
+    def n_closest(self, key: str, n: int, predicate: Optional[Callable[[T], bool]] = None) -> List[str]:
         if self.branch[0] == self.branch[1] == None:
             # leaf of the trie
             if self.metadata is None:
                 return [self.key]
-            else:
+            elif predicate is None or predicate(self.metadata):
                 return [self.metadata]
-        
+            else:
+                return []
+
         nclosest = []
         if self.branch[int(key[len(self.key)])] is not None:
             # get n closest on the closest branch
-            nclosest += self.branch[int(key[len(self.key)])].n_closest(key, n)
-        if len(nclosest) < n and self.branch[1-int(key[len(self.key)])] is not None:    
+            nclosest += self.branch[int(key[len(self.key)])].n_closest(key, n, predicate=predicate)
+        if len(nclosest) < n and self.branch[1 - int(key[len(self.key)])] is not None:
             # if we don't have n keys yet, get the difference from the other branch
-            nclosest += self.branch[1-int(key[len(self.key)])].n_closest(key, n-len(nclosest))
-        return nclosest
+            nclosest += self.branch[1 - int(key[len(self.key)])].n_closest(key, n - len(nclosest), predicate=predicate)
 
+        return nclosest


### PR DESCRIPTION
Hi @guillaumemichel,

this PR includes:

- A .gitignore generated with https://www.toptal.com/developers/gitignore/api/python,macos,linux,visualstudiocode,pycharm,intellij
- Generic typing for the metadata field
- type fix for the n_closest return value - issue #6 
- A predicate function for the `n_closest` method. If the predicate function is set it will only return the n closest for which the predicate condition is true. This is useful e.g., if we want to get the n closest _reachable_ nodes.
- [black code formatting](https://github.com/psf/black) in `pyproject.toml`. I'm using VSCode and it was doing some auto-formatting.

Usually, I would split all of these up in different PRs but I thought of just filing it anyways. Feel free to close this PR and choose only the things you like (if any).

Known Issues:

- The return type of n_closest is either a list of keys (`str`) or a list of (`T`). Not sure how to properly add type annotations for this.